### PR TITLE
[Bug Fix]Fix initial image resizing flicker by enforcing synchronous layout updates

### DIFF
--- a/Sources/Views/ViewComponents/ZoomImageViewComponent/ZoomImageView.swift
+++ b/Sources/Views/ViewComponents/ZoomImageViewComponent/ZoomImageView.swift
@@ -112,24 +112,16 @@ public struct ZoomImageView: UIViewRepresentable {
         context.coordinator.doubleTapZoomScale = doubleTapZoomScale
         context.coordinator.onDragEnd = onDragEnd
         context.coordinator.dragThreshold = dragThreshold
-        
-        // Schedule a delayed layout update to ensure proper initialization
-        DispatchQueue.main.async {
-            context.coordinator.updateImageViewFrame(forceZoomReset: true)
-        }
+        context.coordinator.updateImageViewFrame(forceZoomReset: true)
         
         return scrollView
     }
     
     public func updateUIView(_ uiView: UIScrollView, context: Context) {
         context.coordinator.imageView?.image = image
-        
-        // Schedule a delayed update to ensure proper layout
-        DispatchQueue.main.async {
-            context.coordinator.updateImageViewFrame(forceZoomReset: false)
-            context.coordinator.onDragEnd = onDragEnd
-            context.coordinator.dragThreshold = dragThreshold
-        }
+        context.coordinator.updateImageViewFrame(forceZoomReset: false)
+        context.coordinator.onDragEnd = onDragEnd
+        context.coordinator.dragThreshold = dragThreshold
     }
     
     public func makeCoordinator() -> Coordinator {
@@ -149,7 +141,7 @@ public struct ZoomImageView: UIViewRepresentable {
         func updateImageViewFrame(forceZoomReset: Bool = false) {
             guard let scrollView = scrollView, let imageView = imageView, let image = imageView.image else { return }
 
-            // Update the layout once to fit the screen size
+            // Apply pending layout changes to make sure scrollView.bounds is accurate
             scrollView.layoutIfNeeded()
 
             // Only proceed if the scroll view has valid dimensions

--- a/Sources/Views/ViewComponents/ZoomImageViewComponent/ZoomImageView.swift
+++ b/Sources/Views/ViewComponents/ZoomImageViewComponent/ZoomImageView.swift
@@ -148,7 +148,10 @@ public struct ZoomImageView: UIViewRepresentable {
         
         func updateImageViewFrame(forceZoomReset: Bool = false) {
             guard let scrollView = scrollView, let imageView = imageView, let image = imageView.image else { return }
-            
+
+            // Update the layout once to fit the screen size
+            scrollView.layoutIfNeeded()
+
             // Only proceed if the scroll view has valid dimensions
             if scrollView.bounds.width <= 0 || scrollView.bounds.height <= 0 {
                 // Schedule another attempt if the bounds aren't valid yet


### PR DESCRIPTION
## Overview
This PR addresses an issue in the `ZoomImageView` component where the image is initially displayed at its full (original) dimensions before being resized. During debugging, the image size was reported as `2484x3398`, causing a noticeable flicker as the view updated asynchronously.

## Issue Context
The root cause was identified as the asynchronous invocation of `updateImageViewFrame` using `DispatchQueue.main.async` without ensuring that the scroll view's layout was updated. This delayed the resizing of the `UIImageView`, resulting in the image being rendered at an incorrect size for a brief moment.

## Impact
These changes eliminate the initial flicker caused by displaying the image at full size, particularly for high-resolution images. The result is a smoother and more visually stable experience for the user, with the image correctly sized from the moment it appears.

Fixes #3

## Changes Made
- Added `scrollView.layoutIfNeeded()` in both `makeUIView` and `updateUIView` to force a synchronous layout pass before calculating the zoom scale and image frame.
- Ensures `scrollView.bounds` is correctly set before resizing the image.
- Removed or reduced dependency on delayed asynchronous resizing logic.

## Impact
These changes eliminate the initial flicker caused by displaying the image at full size, particularly for high-resolution images. The result is a smoother and more visually stable experience for the user, with the image correctly sized from the moment it appears.

cc: @ronaldo-avalos